### PR TITLE
Fix index out of range in extractor.py

### DIFF
--- a/src/zdf_auto_dl/action/extractor.py
+++ b/src/zdf_auto_dl/action/extractor.py
@@ -41,7 +41,7 @@ class ZdfExtractor(object):
         title_elements = self.document.cssselect('article.b-content-teaser-item')
         episodes = {}
         for title_element in title_elements:
-            if self.show.lower() not in title_element.cssselect('.teaser-cat-brand-ellipsis')[0].text.lower():
+            if not title_element.cssselect('.teaser-cat-brand-ellipsis') or self.show.lower() not in title_element.cssselect('.teaser-cat-brand-ellipsis')[0].text.lower():
                 continue
             episode_title = title_element.cssselect('a.teaser-title-link .normal-space')[0].text.strip()
             episode_date_str = title_element.cssselect('.special-info')[0].text.strip()


### PR DESCRIPTION
I'm getting the following error on some shows:
```
2025-01-23 20:49:50,139 [ERROR] main.main:71 list index out of range
Traceback (most recent call last):
  File "/app/src/zdf_auto_dl/main.py", line 62, in main
    execute(arguments)
  File "/app/src/zdf_auto_dl/main.py", line 50, in execute
    downloader.start()
  File "/app/src/zdf_auto_dl/action/__init__.py", line 38, in start
    self._download_show(show)
  File "/app/src/zdf_auto_dl/action/__init__.py", line 54, in _download_show
    episodes = zdf_extractor.get_episodes()
  File "/app/src/zdf_auto_dl/action/extractor.py", line 44, in get_episodes
    if self.show.lower() not in title_element.cssselect('.teaser-cat-brand-ellipsis')[0].text.lower():
IndexError: list index out of range
```
This should prevent this error from happening